### PR TITLE
Update openmax.py

### DIFF
--- a/openmax.py
+++ b/openmax.py
@@ -42,7 +42,7 @@ def seperate_data(x,y):
         if sort_y[a] != sort_y[a+1]:
             dataset_x.append(np.array(sort_x[mark:a]))
             dataset_y.append(np.array(sort_y[mark:a]))
-            mark = a
+            mark = a + 1 # here the mark should be updated to the next index.
         if a == len(sort_y)-2:
             dataset_x.append(np.array(sort_x[mark:len(sort_y)]))
             dataset_y.append(np.array(sort_y[mark:len(sort_y)]))


### PR DESCRIPTION
the mark should be updated to a + 1
Take this example:
0000  1111  2222
if you first append the zeros and you save mark = a (= 3) the next time you append you will get in the list [mark,7]: 01111.


you can, of course, optimize this code with this so you save the loop: 


sort_x=np.array(sort_x)
sort_y=np.array(sort_y)
for i in range(len(label)):
      positions= np.where(sort_y==i)[0]
      dataset_x.append(sort_x[positions])
      dataset_y.append(sort_y[positions])